### PR TITLE
Removed version from the build.sbt to fix build issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,8 +5,6 @@ organization := "com.rallyhealth"
 
 organizationName := "Rally Health"
 
-version := "1.0.0"
-
 crossScalaVersions := Seq("2.11.6", "2.10.4")
 
 scalacOptions := {


### PR DESCRIPTION
@chrissalij-r @slustbader This was causing an issue on Jenkins

I think for community open-source projects, we might want to maintain a `communityVersion` setting, so that we can track back to which tag we merged from.

That said, my next community version is going to skip a patch, so that the two will remain equal without conflicting on our artifactory (since this PR will be released with 1.0.1)